### PR TITLE
Declare language in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,5 +32,6 @@ VignetteBuilder:
     knitr
 Config/testthat/edition: 3
 Encoding: UTF-8
+Language: en-US
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -3,3 +3,4 @@ template:
   bootstrap: 5
 development:
   mode: auto
+lang: en-US


### PR DESCRIPTION
Systems assume English if language isn't otherwise declared, but we know what happens when systems (and people) assume.